### PR TITLE
Improve: add custom 404 page

### DIFF
--- a/src/components/Hero404.astro
+++ b/src/components/Hero404.astro
@@ -1,0 +1,30 @@
+---
+---
+
+<div class="bg-white dark:bg-[var(--sl-color-bg)] py-24 md:pt-0">
+  <div class="mx-auto max-w-2xl text-center px-6">
+    <h1 class="text-8xl font-bold text-gray-700 dark:text-white sm:text-9xl">
+      404
+    </h1>
+    
+    <p class="mt-6 text-lg text-gray-500 dark:text-gray-400">
+      Page not found. The page you're looking for doesn't exist.
+    </p>
+    
+    <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+      <a 
+        href="/" 
+        class="rounded-md bg-emerald-600 px-6 py-3 text-sm font-semibold text-white hover:bg-emerald-500 transition-colors no-underline"
+      >
+        Go to Homepage
+      </a>
+      
+      <a 
+        href="/docs/getting-started/introduction" 
+        class="text-sm font-semibold text-gray-700 dark:text-gray-100 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors no-underline"
+      >
+        Browse Documentation →
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/content/docs/404.mdx
+++ b/src/content/docs/404.mdx
@@ -1,0 +1,13 @@
+---
+title: "404 — Page Not Found"
+template: splash
+editUrl: false
+hero:
+  title: "404"
+  
+---
+
+import Hero404 from '../../components/Hero404.astro';
+
+<Hero404 />
+

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,9 +1,21 @@
 /* src/styles/custom.css */
   /* `splash` template > top heading text + container */
-  body:not(:has(#starlight__sidebar)) .content-panel:has(h1#_top) {
+  /* body:not(:has(#starlight__sidebar)) .content-panel:has(h1#_top) {
+    display: none;
+  } */
+
+  /* Hide only the main doc title on splash pages, but show on 404 page */
+  body:not(:has(#starlight__sidebar)) h1#_top {
     display: none;
   }
   
+  /* Override: Show h1#_top specifically when it has data-page-title attribute (like on 404 page) */
+  /* body:not(:has(#starlight__sidebar)) h1#_top[data-page-title] {
+    display: block !important;
+    margin-left: auto;
+    margin-right: auto;
+  } */
+
   body:not(:has(#starlight__sidebar)) .content-panel {
     border: none;
   }


### PR DESCRIPTION
Add custom 404 page (per startlight and astro)

utilized similar pattern to home page, with simple 404 mdx page with an import of astro 404 component.

update custom css to center 404 component.